### PR TITLE
Feat: create existing schema

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config.InitialOptions = {
   displayName: packageJson.name,
   setupFilesAfterEnv: ['./tests/setup.ts'],
   testTimeout: 120000,
+  forceExit: true,
 }
 
 export default config

--- a/src/EthereumApi.ts
+++ b/src/EthereumApi.ts
@@ -17,6 +17,11 @@ export class EthereumApi {
     return schemaDetails
   }
 
+  public async createExistingSchema({ did, schemaId }: { did: string; schemaId: string }) {
+    const schemaDetails = await this.ledgerService.createExistingSchema(this.agentContext, { did, schemaId })
+    return schemaDetails
+  }
+
   public async getSchemaById(did: string, schemaId: string) {
     const schemaDetails = await this.ledgerService.getSchemaByDidAndSchemaId(this.agentContext, did, schemaId)
     return schemaDetails

--- a/src/ledger/EthereumLedgerService.ts
+++ b/src/ledger/EthereumLedgerService.ts
@@ -8,7 +8,7 @@ import { getResolver } from 'ethr-did-resolver'
 
 import { EthereumModuleConfig } from '../EthereumModuleConfig'
 import { EthereumSchemaRegistry } from '../schema/EthereumSchemaRegistry'
-import { buildSchemaResource, uploadSchemaFile } from '../utils/schemaHelper'
+import { buildSchemaResource, getSchemaFile, uploadSchemaFile } from '../utils/schemaHelper'
 import { getPreferredKey, parseAddress } from '../utils/utils'
 
 /**
@@ -34,6 +34,16 @@ export class SchemaRetrievalError extends EthereumLedgerError {
     this.name = 'SchemaRetrievalError'
   }
 }
+export interface Schema {
+  $schema: string
+  $id: string
+  type: string
+  title: string
+  description: string
+  required: string[]
+  properties: Record<string, unknown>
+  definitions: Record<string, unknown>
+}
 
 export interface SchemaCreationResult {
   did: string
@@ -44,6 +54,11 @@ export interface SchemaCreateOptions {
   did: string
   schemaName: string
   schema: object
+}
+
+export interface ExistingSchemaCreateOptions {
+  did: string
+  schemaId: string
 }
 
 @injectable()
@@ -153,6 +168,94 @@ export class EthereumLedgerService {
       // Wrap other errors
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
       agentContext.config.logger.error(`Schema creation failed for DID: ${did}`, error)
+      throw new SchemaCreationError(errorMessage, error instanceof Error ? error : undefined)
+    }
+  }
+
+  /**
+   * Creates existing schema from file server on the Ethereum ledger
+   */
+  public async createExistingSchema(
+    agentContext: AgentContext,
+    { did, schemaId }: ExistingSchemaCreateOptions
+  ): Promise<SchemaCreationResult> {
+    if (!this.schemaManagerContractAddress || !this.rpcUrl || !this.fileServerUrl || !this.fileServerToken) {
+      throw new SchemaCreationError(
+        'Missing required configuration: schemaManagerContractAddress, rpcUrl, fileServerUrl, or fileServerToken'
+      )
+    }
+    // Validate inputs
+    if (!did?.trim()) {
+      throw new SchemaCreationError('DID is required and cannot be empty')
+    }
+    if (!schemaId?.trim()) {
+      throw new SchemaCreationError('Schema Id is required and cannot be empty')
+    }
+
+    agentContext.config.logger.info(`Creating existing schema ${schemaId} on Ethereum for DID: ${did}`)
+
+    try {
+      const schemaJson = await getSchemaFile(schemaId, this.fileServerUrl, this.fileServerToken)
+
+      if (!schemaJson) {
+        throw new SchemaCreationError(`Schema with id ${schemaId} not found on file server`)
+      }
+
+      if (!schemaJson.title) {
+        throw new SchemaCreationError(`Schema name not found in schema with id ${schemaId} on file server`)
+      }
+
+      const schemaName = schemaJson.title
+      const keyResult = await this.getPublicKeyFromDid(agentContext, did)
+
+      if (!keyResult.publicKeyBase58) {
+        throw new CredoError('Public Key not found in wallet')
+      }
+
+      const address = parseAddress(keyResult.blockchainAccountId)
+      const schemaResource = await buildSchemaResource(did, schemaId, schemaName, schemaJson, address)
+      const signingKey = await this.getSigningKey(agentContext.wallet, keyResult.publicKeyBase58)
+
+      const ethSchemaRegistry = new EthereumSchemaRegistry({
+        contractAddress: this.schemaManagerContractAddress,
+        rpcUrl: this.rpcUrl,
+        signingKey: signingKey,
+      })
+
+      let result
+      try {
+        result = await ethSchemaRegistry.createSchema(schemaId, JSON.stringify(schemaResource))
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        const errMsg = (error?.message || '').toLowerCase()
+        if (errMsg.includes('insufficient funds') || errMsg.includes('insufficient balance')) {
+          throw new SchemaCreationError('Insufficient funds to pay for gas fees', error)
+        }
+        throw new SchemaCreationError('Blockchain transaction failed', error)
+      }
+
+      if (!result?.hash) {
+        throw new SchemaCreationError('Invalid response from blockchain')
+      }
+
+      const response: SchemaCreationResult = {
+        did,
+        schemaId,
+        schemaTxnHash: result.hash,
+      }
+
+      agentContext.config.logger.info(`Successfully created schema on ledger for DID: ${did}`)
+
+      return response
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if (error instanceof EthereumLedgerError) {
+        throw error
+      }
+
+      // Wrap other errors
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
+      agentContext.config.logger.error(`Existing Schema creation failed for DID: ${did}`, error)
       throw new SchemaCreationError(errorMessage, error instanceof Error ? error : undefined)
     }
   }

--- a/src/ledger/EthereumLedgerService.ts
+++ b/src/ledger/EthereumLedgerService.ts
@@ -228,9 +228,16 @@ export class EthereumLedgerService {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         const errMsg = (error?.message || '').toLowerCase()
+        const revertReason =
+          error?.revertReason || error?.originalError?.revert?.args?.[0] || error?.originalError?.shortMessage || ''
         if (errMsg.includes('insufficient funds') || errMsg.includes('insufficient balance')) {
           throw new SchemaCreationError('Insufficient funds to pay for gas fees', error)
         }
+
+        if (revertReason === 'SCHEMA_EXISTS' || errMsg.includes('schema_exists')) {
+          throw new SchemaCreationError(`Schema already exists on Ethereum for schemaId ${schemaId}`, error)
+        }
+
         throw new SchemaCreationError('Blockchain transaction failed', error)
       }
 

--- a/src/utils/schemaHelper.ts
+++ b/src/utils/schemaHelper.ts
@@ -1,4 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import type { Schema } from 'src/ledger/EthereumLedgerService'
+
 import axios from 'axios'
 import keccak256 from 'keccak256'
 
@@ -64,6 +66,32 @@ export async function uploadSchemaFile(
     return response
   } catch (error) {
     throw new Error(`Error occurred in uploadSchemaFile function ${error} `)
-    throw error
+  }
+}
+
+export async function getSchemaFile(
+  schemaId: string,
+  fileServerUrl: string,
+  fileServerToken: string
+): Promise<Schema | null> {
+  if (!schemaId) {
+    throw new Error('Schema id is required')
+  }
+
+  try {
+    const response = await axios.get(`${fileServerUrl}/schemas/${encodeURIComponent(schemaId)}`, {
+      headers: {
+        Authorization: `Bearer ${fileServerToken}`,
+      },
+    })
+
+    return response.data
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    if (error?.response?.status === 404) {
+      return null
+    }
+
+    throw new Error(`Failed to get schema ${schemaId} from file server. Error: ${error}`)
   }
 }

--- a/src/utils/schemaHelper.ts
+++ b/src/utils/schemaHelper.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import type { Schema } from 'src/ledger/EthereumLedgerService'
+import type { Schema } from '../ledger/EthereumLedgerService'
 
 import axios from 'axios'
 import keccak256 from 'keccak256'

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -217,59 +217,189 @@ export const EthereumDIDFixtures = {
 }
 
 export const testSchemaSample = {
-  '@context': [
-    {
-      '@version': 1.1,
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: '2024-06-17T10:01:35.069Z-Academic Certificate',
+  type: 'object',
+  required: ['@context', 'issuer', 'issuanceDate', 'type', 'credentialSubject'],
+  properties: {
+    '@context': {
+      $ref: '#/definitions/context',
     },
-    'https://www.w3.org/ns/odrl.jsonld',
-    {
-      ex: 'https://example.org/examples#',
-      schema: 'http://schema.org/',
-      rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-
-      '3rdPartyCorrelation': 'ex:3rdPartyCorrelation',
-      AllVerifiers: 'ex:AllVerifiers',
-      Archival: 'ex:Archival',
-      BachelorDegree: 'ex:BachelorDegree',
-      Child: 'ex:Child',
-      CLCredentialDefinition2019: 'ex:CLCredentialDefinition2019',
-      CLSignature2019: 'ex:CLSignature2019',
-      IssuerPolicy: 'ex:IssuerPolicy',
-      HolderPolicy: 'ex:HolderPolicy',
-      Mother: 'ex:Mother',
-      RelationshipCredential: 'ex:RelationshipCredential',
-      UniversityDegreeCredential: 'ex:UniversityDegreeCredential',
-      AlumniCredential: 'ex:AlumniCredential',
-      DisputeCredential: 'ex:DisputeCredential',
-      PrescriptionCredential: 'ex:PrescriptionCredential',
-      ZkpExampleSchema2018: 'ex:ZkpExampleSchema2018',
-
-      issuerData: 'ex:issuerData',
-      attributes: 'ex:attributes',
-      signature: 'ex:signature',
-      signatureCorrectnessProof: 'ex:signatureCorrectnessProof',
-      primaryProof: 'ex:primaryProof',
-      nonRevocationProof: 'ex:nonRevocationProof',
-
-      alumniOf: { '@id': 'schema:alumniOf', '@type': 'rdf:HTML' },
-      child: { '@id': 'ex:child', '@type': '@id' },
-      degree: 'ex:degree',
-      degreeType: 'ex:degreeType',
-      degreeSchool: 'ex:degreeSchool',
-      college: 'ex:college',
-      name: { '@id': 'schema:name', '@type': 'rdf:HTML' },
-      givenName: 'schema:givenName',
-      familyName: 'schema:familyName',
-      parent: { '@id': 'ex:parent', '@type': '@id' },
-      referenceId: 'ex:referenceId',
-      documentPresence: 'ex:documentPresence',
-      evidenceDocument: 'ex:evidenceDocument',
-      spouse: 'schema:spouse',
-      subjectPresence: 'ex:subjectPresence',
-      verifier: { '@id': 'ex:verifier', '@type': '@id' },
-      currentStatus: 'ex:currentStatus',
-      statusReason: 'ex:statusReason',
-      prescription: 'ex:prescription',
+    type: {
+      type: 'array',
+      items: {
+        anyOf: [
+          {
+            $ref: '#/definitions/VerifiableCredential',
+          },
+          {
+            const: '#/definitions/$Academic Certificate',
+          },
+        ],
+      },
     },
-  ],
+    credentialSubject: {
+      $ref: '#/definitions/credentialSubject',
+    },
+    id: {
+      type: 'string',
+      format: 'uri',
+    },
+    issuer: {
+      $ref: '#/definitions/uriOrId',
+    },
+    issuanceDate: {
+      type: 'string',
+      format: 'date-time',
+    },
+    expirationDate: {
+      type: 'string',
+      format: 'date-time',
+    },
+    credentialStatus: {
+      $ref: '#/definitions/credentialStatus',
+    },
+    credentialSchema: {
+      $ref: '#/definitions/credentialSchema',
+    },
+  },
+  definitions: {
+    context: {
+      type: 'array',
+      items: [
+        {
+          const: 'https://www.w3.org/2018/credentials/v1',
+        },
+      ],
+      additionalItems: {
+        oneOf: [
+          {
+            type: 'string',
+            format: 'uri',
+          },
+          {
+            type: 'object',
+          },
+          {
+            type: 'array',
+            items: {
+              $ref: '#/definitions/context',
+            },
+          },
+        ],
+      },
+      minItems: 1,
+      uniqueItems: true,
+    },
+    credentialSubject: {
+      type: 'object',
+      required: ['id'],
+      additionalProperties: false,
+      properties: {
+        id: {
+          type: 'string',
+          format: 'uri',
+        },
+        'Issuer Name': {
+          type: 'string',
+          order: 0,
+          title: 'Issuer Name',
+        },
+        'Student ID': {
+          type: 'number',
+          order: 1,
+          title: 'Student ID',
+        },
+        'Student Name': {
+          type: 'string',
+          order: 2,
+          title: 'Student Name',
+        },
+        'Title of Award': {
+          type: 'string',
+          order: 3,
+          title: 'Title of Award',
+        },
+        'College Name': {
+          type: 'string',
+          order: 4,
+          title: 'College Name',
+        },
+        revocation_id: {
+          type: 'string',
+          order: 5,
+          title: 'revocation_id',
+        },
+      },
+    },
+    VerifiableCredential: {
+      const: 'VerifiableCredential',
+    },
+    credentialSchema: {
+      oneOf: [
+        {
+          $ref: '#/definitions/idAndType',
+        },
+        {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/idAndType',
+          },
+          minItems: 1,
+          uniqueItems: true,
+        },
+      ],
+    },
+    credentialStatus: {
+      oneOf: [
+        {
+          $ref: '#/definitions/idAndType',
+        },
+        {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/idAndType',
+          },
+          minItems: 1,
+          uniqueItems: true,
+        },
+      ],
+    },
+    idAndType: {
+      type: 'object',
+      required: ['id', 'type'],
+      properties: {
+        id: {
+          type: 'string',
+          format: 'uri',
+        },
+        type: {
+          type: 'string',
+        },
+      },
+    },
+    uriOrId: {
+      oneOf: [
+        {
+          type: 'string',
+          format: 'uri',
+        },
+        {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uri',
+            },
+          },
+        },
+      ],
+    },
+    'Academic Certificate': {
+      const: 'Academic Certificate',
+    },
+  },
+  title: 'Academic Certificate',
+  description: 'Academic Certificate',
 }

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -75,7 +75,6 @@ describe('Schema Operations', () => {
     faberAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
     faberAgent.registerInboundTransport(new SubjectInboundTransport(faberMessages))
     await faberAgent.initialize()
-
     const createdDid = await faberAgent.dids.create<EthereumDidCreateOptions>({
       method: 'ethr',
       options: {
@@ -146,6 +145,51 @@ describe('Schema Operations', () => {
           schema: testSchemaSample,
         })
       ).rejects.toThrow(EthereumLedgerError)
+    })
+  })
+
+  describe('Create Existing Schema', () => {
+    it('should create existing W3C schema from another ledger on Ethereum', async () => {
+      const validExistingSchemaId = '0c66b9b7-76af-4025-a3bc-55218ef18763'
+      const result = await faberAgent.modules.ethereum.createExistingSchema({
+        did,
+        schemaId: validExistingSchemaId,
+      })
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          did,
+          schemaId: validExistingSchemaId,
+          schemaTxnHash: expect.any(String),
+        })
+      )
+    })
+
+    it('should throw if schemaId is empty', async () => {
+      await expect(
+        faberAgent.modules.ethereum.createExistingSchema({
+          did,
+          schemaId: '',
+        })
+      ).rejects.toThrow('Schema Id is required')
+    })
+
+    it('should throw if DID is empty', async () => {
+      await expect(
+        faberAgent.modules.ethereum.createExistingSchema({
+          did: '',
+          schemaId: 'schema:example:1',
+        })
+      ).rejects.toThrow('DID is required')
+    })
+
+    it('should fail if schema does not exist on file server', async () => {
+      await expect(
+        faberAgent.modules.ethereum.createExistingSchema({
+          did,
+          schemaId: 'non-existent-schema-id',
+        })
+      ).rejects.toThrow('not found on file server')
     })
   })
 

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -191,6 +191,18 @@ describe('Schema Operations', () => {
         })
       ).rejects.toThrow('not found on file server')
     })
+
+    it('should throw SchemaCreationError when schema already exists on Ethereum', async () => {
+      const duplicateSchemaId = schemaId
+      await expect(
+        faberAgent.modules.ethereum.createExistingSchema({
+          did,
+          schemaId: duplicateSchemaId,
+        })
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('Schema already exists'),
+      })
+    })
   })
 
   describe('Schema Retrieval', () => {


### PR DESCRIPTION
This PR introduces the `createExistingSchema` functionality in the EthereumModule, allowing
existing W3C schemas from another ledger or environment to be created on Ethereum.

**Key changes:**
- Added `createExistingSchema` to:
  - Fetch schema from the file server by schemaId
  - Build the schema resource for Ethereum ledger
  - Submit the schema to the Ethereum schema registry
- Detect and handle `SCHEMA_EXISTS` blockchain error, throwing a clear
  `SchemaCreationError` with message: "Schema already exists"
- Retain existing handling for:
  - Insufficient funds / gas errors
  - File server missing schema or invalid schema content
- Updated E2E tests to cover:
  - Successful creation of existing schemas
  - SCHEMA_EXISTS error scenario
  - Missing schema or invalid input cases